### PR TITLE
better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT"
 description = "What if correct horse battery staple, but Pokémon."
 readme = "README.md"
-homepage = "https://github.com/jbhannah/pkpw"
+repository = "https://github.com/jbhannah/pkpw"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
To allow https://crates.io/ , https://lib.rs/ and https://rust-digger.code-maven.com/ to link to it
See also https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field
