### PR TITLE
⚡ Optimize string joining in `join` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,14 +68,21 @@ pub fn generate<R: Rng>(
 /// Join the collection of items with random selections from the set of possible
 /// separators.
 pub fn join<R: Rng + ?Sized>(picked: Vec<&str>, separators: &[char], rng: &mut R) -> String {
-    picked
-        .into_iter()
-        .map(|name| name.to_owned())
-        .reduce(|password, next| {
-            let i = rng.random::<u32>() as usize % separators.len();
-            format!("{}{}{}", password, separators[i], next)
-        })
-        .unwrap_or_else(|| "".to_string())
+    let mut iter = picked.into_iter();
+    let first = match iter.next() {
+        Some(first) => first,
+        None => return String::new(),
+    };
+
+    let mut result = first.to_owned();
+
+    for next in iter {
+        let i = rng.random::<u32>() as usize % separators.len();
+        result.push(separators[i]);
+        result.push_str(next);
+    }
+
+    result
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The `join` function previously used `reduce` with `format!`, which resulted in quadratic ($O(N^2)$) string allocations and copies as the password was built up word by word.

This change refactors the function to use a single mutable `String` and appends to it in a loop using `push` and `push_str`. This reduces the complexity to $O(N)$ time and significantly reduces memory allocations, especially for passwords with many words.

Functional correctness was verified with a standalone script comparing the original and optimized implementations.

**Measured Improvement:**
While full benchmarks were impractical due to environment constraints, the theoretical improvement from $O(N^2)$ to $O(N)$ is a standard performance win for string concatenation in Rust. For a 10-word password, this reduces the number of intermediate string allocations from 9 large, repeated copies to a single growing buffer.

---
*PR created automatically by Jules for task [10055009915368363992](https://jules.google.com/task/10055009915368363992) started by @jbhannah*