### PR TITLE
🔒 [security fix] Add input validation and clamping to WASM interface

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -3,6 +3,10 @@ use wasm_bindgen::prelude::*;
 
 use crate::generate;
 
+const MAX_LEN: usize = 1024;
+const MAX_COUNT: usize = 1024;
+const MAX_APPEND_NUMBERS: usize = 256;
+
 /// Generate a Pokémon password with the optional minimum length or word count,
 /// the given optional list of separators, or "digit" or "symbol" to use
 /// predefined lists of separators, and optional number of digits to append.
@@ -11,10 +15,10 @@ pub fn pkpw(len: Option<usize>, count: Option<usize>, separator: Option<String>,
     let mut rng = rng();
 
     generate(
-        len,
-        count.unwrap_or(4),
+        len.map(|v| v.min(MAX_LEN)),
+        count.map(|v| v.min(MAX_COUNT)).unwrap_or(4),
         &(separator.unwrap_or(" ".to_string())),
-        append_numbers,
+        append_numbers.map(|v| v.min(MAX_APPEND_NUMBERS)),
         &mut rng,
     )
 }
@@ -93,5 +97,39 @@ mod test {
         for &ch in last_five {
             assert!(ch.is_ascii_digit());
         }
+    }
+
+    #[wasm_bindgen_test]
+    fn clamps_large_inputs() {
+        use crate::wasm::{MAX_APPEND_NUMBERS, MAX_COUNT, MAX_LEN};
+
+        // Check that a very large length is clamped
+        let password = pkpw(Some(usize::MAX), None, None, None);
+        // It should be at least MAX_LEN, but not excessively large
+        // POKEMON_COUNT is 1028, and each name has some length.
+        // If we requested usize::MAX, it would try to take all pokemon and then fail if it still hasn't reached it.
+        // With clamping, it should stop much earlier.
+        assert!(password.len() >= MAX_LEN);
+        // It's hard to assert the exact upper bound because it depends on pokemon name lengths,
+        // but it should definitely not be millions of characters.
+        assert!(password.len() < MAX_LEN + 100);
+
+        // Check that a very large count is clamped
+        let password = pkpw(None, Some(usize::MAX), None, None);
+        let words = password.split(' ').count();
+        // It should be exactly MAX_COUNT because Pokemon::pick(count) takes `count` items.
+        assert_eq!(words, MAX_COUNT);
+
+        // Check that a very large append_numbers is clamped
+        let password = pkpw(None, None, None, Some(usize::MAX));
+        // The last MAX_APPEND_NUMBERS should be digits
+        let chars: Vec<char> = password.chars().collect();
+        let last_part = &chars[chars.len() - MAX_APPEND_NUMBERS..];
+        for &ch in last_part {
+            assert!(ch.is_ascii_digit());
+        }
+        // And the character before that should NOT be a digit (it should be a space or part of a pokemon name)
+        let before_last_part = chars[chars.len() - MAX_APPEND_NUMBERS - 1];
+        assert!(!before_last_part.is_ascii_digit() || before_last_part == '2'); // Porygon2 is an exception
     }
 }


### PR DESCRIPTION
### 🎯 What:
This PR addresses a missing validation vulnerability in the WebAssembly (WASM) interface of `pkpw`. It introduces maximum limits for the `len`, `count`, and `append_numbers` parameters.

### ⚠️ Risk:
Without these validations, a malicious or accidental input of extremely large values (e.g., `usize::MAX`) could lead to excessive memory allocation or CPU cycles in the browser, potentially causing the tab or the entire browser to hang or crash (Denial of Service).

### 🛡️ Solution:
- Introduced constants: `MAX_LEN = 1024`, `MAX_COUNT = 1024`, and `MAX_APPEND_NUMBERS = 256`.
- Modified the `pkpw` function in `src/wasm.rs` to clamp the optional input values to these maximums using `.map(|v| v.min(MAX_LIMIT))`.
- Added a comprehensive test case `clamps_large_inputs` in the WASM module to ensure that large values are correctly handled without causing panics or excessive resource usage.

---
*PR created automatically by Jules for task [6564759956094945717](https://jules.google.com/task/6564759956094945717) started by @jbhannah*