### PR TITLE
🧹 [code health] avoid unnecessary string allocation in generate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub fn generate<R: Rng>(
         None => pokemon.pick(count),
     };
 
-    let password = match separator {
+    let mut password = match separator {
         "digit" => join(picked, DIGITS, rng),
         "special" => join(picked, SPECIAL, rng),
         "random" => {
@@ -53,16 +53,14 @@ pub fn generate<R: Rng>(
         sep => picked.join(sep),
     };
 
-    let mut numbers = String::new();
-
     if let Some(num_digits) = append_numbers {
         for _ in 0..num_digits {
             let i = rng.random::<u32>() as usize % DIGITS.len();
-            numbers.push(DIGITS[i]);
+            password.push(DIGITS[i]);
         }
     }
 
-    format!("{}{}", password, numbers)
+    password
 }
 
 /// Join the collection of items with random selections from the set of possible

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub fn generate<R: Rng>(
     };
 
     if let Some(num_digits) = append_numbers {
+        password.reserve(num_digits);
         for _ in 0..num_digits {
             let i = rng.random::<u32>() as usize % DIGITS.len();
             password.push(DIGITS[i]);


### PR DESCRIPTION
The `generate` function previously used an intermediate `String` to collect random digits and then merged this with the `password` string using the `format!` macro. This resulted in multiple unnecessary string allocations.

This change:
- Makes the `password` variable mutable.
- Appends random digits directly to `password` using `.push()`.
- Returns `password` directly, eliminating the final `format!` call.

These changes improve both the performance and readability of the code without changing its behavior.

Verification:
- Inspected the code manually.
- Verified the refactoring logic using a temporary script (the Rust toolchain was unavailable due to environment/network issues preventing crate fetching).

---
*PR created automatically by Jules for task [8164000906082996808](https://jules.google.com/task/8164000906082996808) started by @jbhannah*