### PR TITLE
🧹 [code health improvement] Use unwrap_or_default() instead of unwrap_or_else(|| "".to_string())

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub fn join<R: Rng + ?Sized>(picked: Vec<&str>, separators: &[char], rng: &mut R
             let i = rng.random::<u32>() as usize % separators.len();
             format!("{}{}{}", password, separators[i], next)
         })
-        .unwrap_or_else(|| "".to_string())
+        .unwrap_or_default()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Replaced `.unwrap_or_else(|| "".to_string())` with `.unwrap_or_default()` in the `join` function in `src/lib.rs`.

💡 **Why:** How this improves maintainability
- Simplifies code by using a built-in trait method instead of a closure allocation.
- Follows idiomatic Rust patterns for `Option<String>` defaults.

✅ **Verification:** How you confirmed the change is safe
- Created a standalone Rust script `verify_join.rs` that implemented the same `join` logic with `unwrap_or_default()`.
- Tested with normal, single-item, and empty input vectors, confirming it returns the correct joined string or an empty string.
- Compiled and ran the verification script using the local toolchain's `rustc`.

✨ **Result:** The improvement achieved
- Improved the maintainability and readability of `src/lib.rs` with zero changes in behavior.


---
*PR created automatically by Jules for task [6518032638239019229](https://jules.google.com/task/6518032638239019229) started by @jbhannah*