### PR TITLE
🧪 [testing improvement] Add edge case test for join with empty list

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,15 @@ mod test {
         );
     }
 
+    /// Ensure that join() returns an empty string when the list of items is empty.
+    #[test]
+    fn test_join_empty() {
+        let mut rng = rng_from_seed(POKEMON_COUNT);
+        let picked = vec![];
+
+        assert_eq!("", join(picked, DIGITS, &mut rng));
+    }
+
     /// Ensure that generate(…, …, …, 3, …) appends 3 random digits to the password.
     #[test]
     fn test_generate_append_numbers() {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing edge case test for the `join` function when given an empty list.
📊 **Coverage:** What scenarios are now tested: `join` called with an empty vector of strings.
✨ **Result:** The improvement in test coverage: Increased reliability of the `join` function by ensuring it correctly returns an empty string when no items are provided.

---
*PR created automatically by Jules for task [10312032764640628971](https://jules.google.com/task/10312032764640628971) started by @jbhannah*