### PR TITLE
🧹 remove redundant type declaration in ButtonProps

### DIFF
--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -2,7 +2,6 @@ import type { ComponentProps } from "preact";
 
 interface ButtonProps extends ComponentProps<"button"> {
   classes?: string;
-  type?: "button" | "submit" | "reset";
 }
 
 const Button = ({ classes, type, ...props }: Readonly<ButtonProps>) => (


### PR DESCRIPTION
### 🎯 **What:** The code health issue addressed
Removed the redundant `type?: "button" | "submit" | "reset";` declaration from the `ButtonProps` interface in `web/src/components/Button.tsx`.

### 💡 **Why:** How this improves maintainability
The `type` property is already included in `ComponentProps<"button">`, which `ButtonProps` extends. Removing the redundant declaration reduces code duplication and relies on the standard types provided by Preact, making the codebase cleaner and easier to maintain.

### ✅ **Verification:** How you confirmed the change is safe
- Verified that `ButtonProps` still inherits the `type` property from `ComponentProps<"button">`.
- Confirmed that the `Button` component correctly handles the `type` prop and its default value.
- Attempted to run `pnpm run check` and `pnpm run build` (though blocked by environment network/dependency limitations).
- Conducted manual code review to ensure no other components had similar redundant declarations.

### ✨ **Result:** The improvement achieved
Improved code readability and reduced redundancy in the `Button` component's props definition.

---
*PR created automatically by Jules for task [6720489902333482172](https://jules.google.com/task/6720489902333482172) started by @jbhannah*